### PR TITLE
Support building for non-OpenCL targets

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,13 +1,24 @@
-QRACKVER = qrack_ocl.cpp #qrack_ocl.cpp, qrack.cpp or qrack_serial.cpp
+# 1 to use OpenCL-based optimizations
+ENABLE_OPENCL ?= 1
+
 CPP      = g++
 OBJ      = complex16simd.o qrack.o example.o
 LINKOBJ  = complex16simd.o qrack.o example.o
 BIN      = example
-LIBS     = -lm -lpthread -lOpenCL
+LIBS     = -lm -lpthread
 INCS     =
 CXXINCS  = 
 CXXFLAGS = $(CXXINCS) -std=c++11 -Wall -pedantic
 RM       = rm -f
+
+ifeq (${ENABLE_OPENCL},1)
+  LIBS += -lOpenCL
+  CXXFLAGS += -DENABLE_OPENCL=1
+  QRACKVER = qrack_ocl.cpp
+else
+  CXXFLAGS += -DENABLE_OPENCL=0
+  QRACKVER = qrack.cpp # or optionally 'qrack_serial.cpp'
+endif
 
 .PHONY: all all-before all-after clean clean-custom
 

--- a/qrack.hpp
+++ b/qrack.hpp
@@ -22,10 +22,12 @@
 #include <thread>
 #include <future>
 
+#if ENABLE_OPENCL
 #ifdef __APPLE__
     #include <OpenCL/cl.hpp>
 #else
     #include <CL/cl.hpp>
+#endif
 #endif
 
 #include "complex16simd.hpp"
@@ -43,6 +45,7 @@ namespace Qrack {
 	template <class BidirectionalIterator>
 	void rotate (BidirectionalIterator first, BidirectionalIterator middle, BidirectionalIterator last,  bitCapInt stride);
 
+#if ENABLE_OPENCL
 	/// "Qrack::OCLSingleton" manages the single OpenCL context
 	/** "Qrack::OCLSingleton" manages the single OpenCL context. */
 	class OCLSingleton{
@@ -106,6 +109,8 @@ namespace Qrack {
 
 			void InitOCL(int plat, int dev);
 	};
+#endif  /* ENABLE_OPENCL */
+
 	/// The "Qrack::CoherentUnit" class represents one or more coherent quantum processor registers		
 	/** The "Qrack::CoherentUnit" class represents one or more coherent quantum processor registers, including primitive bit logic gates and (abstract) opcodes-like methods. */
 	class CoherentUnit {
@@ -395,6 +400,7 @@ namespace Qrack {
 			std::default_random_engine rand_generator;
 			std::uniform_real_distribution<double> rand_distribution;
 
+#if ENABLE_OPENCL
 			OCLSingleton* clObj;
 			cl::CommandQueue queue;
 			cl::Buffer stateBuffer;
@@ -403,14 +409,16 @@ namespace Qrack {
 			cl::Buffer nrmBuffer;
 			cl::Buffer maxBuffer;
 
+			void InitOCL();
+			void ReInitOCL();
+#endif /* ENABLE_OPENCL */
+
 			void Apply2x2(bitCapInt offset1, bitCapInt offset2, const Complex16* mtrx,
 					const bitLenInt bitCount, const bitCapInt* qPowersSorted, bool doApplyNorm, bool doCalcNorm);
 			void ApplySingleBit(bitLenInt qubitIndex, const Complex16* mtrx, bool doCalcNorm);
 			void ApplyControlled2x2(bitLenInt control, bitLenInt target, const Complex16* mtrx, bool doCalcNorm);
 			void ApplyAntiControlled2x2(bitLenInt control, bitLenInt target, const Complex16* mtrx, bool doCalcNorm);
 			void Carry(bitLenInt integerStart, bitLenInt integerLength, bitLenInt carryBit);
-			void InitOCL();
-			void ReInitOCL();
 			void NormalizeState();
 			void Reverse(bitLenInt first, bitLenInt last);
 			void UpdateRunningNorm();


### PR DESCRIPTION
Allow specifying ENABLE_OPENCL on the command line to control enabling or
disabling OpenCL on the command line.  The default in the Makefile remains as
'enabled'.

Example command line:

```bash
		# Build as normal, with OpenCL support.
		$ make
		...
		# Build with OpenCL support disabled.
		$ ENABLE_OPENCL=0 make
		...
		# Build with OpenCL support explicitly enabled.
		$ ENABLE_OPENCL=1 make
		...
		$
```