### PR TITLE
Coverage and Format support in CMake (#51)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,34 +4,8 @@ project (QRack VERSION 1.0 DESCRIPTION "High Performance Quantum Bit Simulation"
 # Installation commands
 include (GNUInstallDirs)
 
-set (OPENCL_AMDSDK /opt/AMDAPPSDK-3.0 CACHE PATH "Installation path for the installed AMD OpenCL SDK, if used")
-option (ENABLE_OPENCL "Use OpenCL optimizations" ON)
-
-# Options used when building the project
-find_library (LIB_OPENCL OpenCL)
-if (NOT LIB_OPENCL)
-    # Attempt with AMD's OpenCL SDK
-    find_library (LIB_OPENCL OpenCL PATHS ${OPENCL_AMDSDK}/lib/x86_64/)
-    if (NOT LIB_OPENCL)
-        set (ENABLE_OPENCL OFF)
-    else ()
-        # Found, set the required include path.
-        set (OPENCL_INCLUDE_PATH ${OPENCL_AMDSDK}/include CACHE PATH "AMD OpenCL SDK Header include path")
-        set (OPENCL_COMPILATION_OPTIONS
-            -Wno-ignored-attributes
-            -Wno-deprecated-declarations
-            CACHE STRING "AMD OpenCL SDK Compilation Option Requirements")
-        message ("OpenCL support found in the AMD SDK")
-    endif ()
-endif ()
-
-message ("OpenCL Support is: ${ENABLE_OPENCL}")
-
-if (ENABLE_OPENCL)
-    message ("    libOpenCL: ${LIB_OPENCL}")
-    message ("    Includes:  ${OPENCL_INCLUDE_PATH}")
-    message ("    Options:   ${OPENCL_COMPILATION_OPTIONS}")
-endif ()
+include ("cmake/Coverage.cmake")
+include ("cmake/Format.cmake" )
 
 include_directories ("include" "include/common")
 
@@ -65,6 +39,9 @@ add_test (NAME qrack_tests
     COMMAND unittest
     )
 
+# Included after the library and other modules have been declared
+include ("cmake/OpenCL.cmake" )
+
 enable_testing()
 
 # Run the unittest executable on 'make test'
@@ -74,44 +51,6 @@ target_include_directories (unittest PUBLIC test)
 target_compile_options (qrack PUBLIC -ggdb -std=c++11 -Wall -Werror -DCATCH_CONFIG_FAST_COMPILE)
 target_compile_options (unittest PUBLIC -ggdb -std=c++11 -Wall -Werror -DCATCH_CONFIG_FAST_COMPILE)
 
-if (ENABLE_OPENCL)
-    target_compile_definitions (qrack PUBLIC ENABLE_OPENCL=1)
-
-    # Include the necessary options and libraries to link against
-    target_include_directories (qrack PUBLIC ${PROJECT_BINARY_DIR} ${OPENCL_INCLUDE_PATH})
-    target_compile_options (qrack PUBLIC ${OPENCL_COMPILATION_OPTIONS})
-    target_link_libraries (unittest ${LIB_OPENCL})
-
-    # Build the OpenCL command files
-    find_program (XXD_BIN xxd)
-    file (GLOB_RECURSE COMPILED_RESOURCES "src/qengine/state/*.cl")
-    foreach (INPUT_FILE ${COMPILED_RESOURCES})
-        get_filename_component (INPUT_NAME ${INPUT_FILE} NAME)
-        get_filename_component (INPUT_BASENAME ${INPUT_FILE} NAME_WE)
-        get_filename_component (INPUT_DIR ${INPUT_FILE} DIRECTORY)
-
-        set (OUTPUT_FILE ${PROJECT_BINARY_DIR}/${INPUT_BASENAME}cl.hpp)
-
-        message (" Creating XXD Rule for ${INPUT_FILE} -> ${OUTPUT_FILE}")
-        add_custom_command (
-            WORKING_DIRECTORY ${INPUT_DIR}
-            OUTPUT ${OUTPUT_FILE}
-            COMMAND ${XXD_BIN} -i ${INPUT_NAME} > ${OUTPUT_FILE}
-            COMMENT "Building OpenCL Commands in ${INPUT_FILE}"
-            )
-        list (APPEND COMPILED_RESOURCES ${OUTPUT_FILE})
-    endforeach ()
-
-    # Add the OpenCL objects to the library
-    target_sources (qrack PRIVATE
-        ${COMPILED_RESOURCES}
-        src/common/oclengine.cpp
-        src/qengine/state/opencl.cpp
-        )
-
-else (ENABLE_OPENCL)
-    target_compile_definitions (qrack PUBLIC ENABLE_OPENCL=0)
-endif (ENABLE_OPENCL)
 
 set_target_properties (qrack PROPERTIES
     VERSION ${PROJECT_VERSION}

--- a/README.md
+++ b/README.md
@@ -61,6 +61,18 @@ Similarly, the "Decohere" and "Dispose" methods should only be used on qubits th
 
 Qrack is an experimental work in progress, and the author aims for both utility and correctness, but the project cannot be guaranteed to be fit for any purpose, express or implied. (See LICENSE.md for details.)
 
+## Performing code coverage
+
+```
+    $ cd _build
+    $ cmake -DENABLE_CODECOVERAGE=ON ..
+    $ make -j 8 unittest
+    $ ./unittest
+    $ make coverage
+    $ cd coverage_results
+    $ python -m SimpleHTTPServer
+```
+
 ## Copyright and License
 
 Copyright (c) Daniel Strano 2017, (with many thanks to Benn Bollay for tool chain development in particular, and also Marek Karcz for supplying an awesome base classical 6502 emulator for proof-of-concept). All rights reserved. (See "par_for.hpp" for additional information.)

--- a/cmake/Coverage.cmake
+++ b/cmake/Coverage.cmake
@@ -1,0 +1,31 @@
+option ( ENABLE_CODECOVERAGE "Enable code coverage testing support" )
+
+if ( ENABLE_CODECOVERAGE )
+    message( "Code coverage enabled" )
+
+    # Set the default options
+    if ( NOT DEFINED CODECOV_OUTPUTFILE )
+        set( CODECOV_OUTPUTFILE cmake_coverage.output )
+    endif ( NOT DEFINED CODECOV_OUTPUTFILE )
+
+    if ( NOT DEFINED CODECOV_HTMLOUTPUTDIR )
+        set( CODECOV_HTMLOUTPUTDIR coverage_results )
+    endif ( NOT DEFINED CODECOV_HTMLOUTPUTDIR )
+
+    # Enable block for GCC - other blocks for other compilers would be necessary.
+    if ( CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_GNUCXX )
+        find_program( CODECOV_GCOV gcov )
+        find_program( CODECOV_LCOV lcov )
+        find_program( CODECOV_GENHTML genhtml )
+        add_definitions( -fprofile-arcs -ftest-coverage )
+        link_libraries( gcov )
+        set( CMAKE_EXE_LINKER_FLAGS ${CMAKE_EXE_LINKER_FLAGS} --coverage )
+
+        # Use 'make coverage' to build coverage report after running a test
+        add_custom_target( coverage_init ALL ${CODECOV_LCOV} --base-directory .  --directory ${CMAKE_BINARY_DIR} --output-file ${CODECOV_OUTPUTFILE} --capture --initial )
+        add_custom_target( coverage ${CODECOV_LCOV} --base-directory .  --directory ${CMAKE_BINARY_DIR} --output-file ${CODECOV_OUTPUTFILE} --capture COMMAND genhtml -o ${CODECOV_HTMLOUTPUTDIR} ${CODECOV_OUTPUTFILE} )
+    endif ( CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_GNUCXX )
+
+else ( ENABLE_CODECOVERAGE )
+    message( "Code coverage disabled" )
+endif ( ENABLE_CODECOVERAGE )

--- a/cmake/Format.cmake
+++ b/cmake/Format.cmake
@@ -1,0 +1,20 @@
+set( FORMAT_EXCLUDE_FILES "catch.hpp" "_build")
+
+find_program ( CLANG_FORMAT clang-format-5.0 )
+file (GLOB_RECURSE ALL_SOURCE_FILES *.cpp *.hpp)
+
+foreach (SOURCE_FILE ${ALL_SOURCE_FILES})
+    foreach (EXCLUDE_FILE ${FORMAT_EXCLUDE_FILES})
+		string (FIND ${SOURCE_FILE} ${EXCLUDE_FILE} EXCLUDE)
+		if (NOT ${EXCLUDE} EQUAL -1)
+			list(REMOVE_ITEM ALL_SOURCE_FILES ${SOURCE_FILE})
+		endif ()
+    endforeach ()
+endforeach ()
+
+add_custom_target (
+    format
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+    COMMAND ${CLANG_FORMAT} -style=file -i ${ALL_SOURCE_FILES}
+    )
+

--- a/cmake/OpenCL.cmake
+++ b/cmake/OpenCL.cmake
@@ -1,0 +1,68 @@
+option (ENABLE_OPENCL "Use OpenCL optimizations" ON)
+
+set (OPENCL_AMDSDK /opt/AMDAPPSDK-3.0 CACHE PATH "Installation path for the installed AMD OpenCL SDK, if used")
+
+# Options used when building the project
+find_library (LIB_OPENCL OpenCL)
+if (NOT LIB_OPENCL)
+    # Attempt with AMD's OpenCL SDK
+    find_library (LIB_OPENCL OpenCL PATHS ${OPENCL_AMDSDK}/lib/x86_64/)
+    if (NOT LIB_OPENCL)
+        set (ENABLE_OPENCL OFF)
+    else ()
+        # Found, set the required include path.
+        set (OPENCL_INCLUDE_PATH ${OPENCL_AMDSDK}/include CACHE PATH "AMD OpenCL SDK Header include path")
+        set (OPENCL_COMPILATION_OPTIONS
+            -Wno-ignored-attributes
+            -Wno-deprecated-declarations
+            CACHE STRING "AMD OpenCL SDK Compilation Option Requirements")
+        message ("OpenCL support found in the AMD SDK")
+    endif ()
+endif ()
+
+message ("OpenCL Support is: ${ENABLE_OPENCL}")
+
+if (ENABLE_OPENCL)
+    message ("    libOpenCL: ${LIB_OPENCL}")
+    message ("    Includes:  ${OPENCL_INCLUDE_PATH}")
+    message ("    Options:   ${OPENCL_COMPILATION_OPTIONS}")
+endif ()
+
+if (ENABLE_OPENCL)
+    target_compile_definitions (qrack PUBLIC ENABLE_OPENCL=1)
+
+    # Include the necessary options and libraries to link against
+    target_include_directories (qrack PUBLIC ${PROJECT_BINARY_DIR} ${OPENCL_INCLUDE_PATH})
+    target_compile_options (qrack PUBLIC ${OPENCL_COMPILATION_OPTIONS})
+    target_link_libraries (unittest ${LIB_OPENCL})
+
+    # Build the OpenCL command files
+    find_program (XXD_BIN xxd)
+    file (GLOB_RECURSE COMPILED_RESOURCES "src/qengine/state/*.cl")
+    foreach (INPUT_FILE ${COMPILED_RESOURCES})
+        get_filename_component (INPUT_NAME ${INPUT_FILE} NAME)
+        get_filename_component (INPUT_BASENAME ${INPUT_FILE} NAME_WE)
+        get_filename_component (INPUT_DIR ${INPUT_FILE} DIRECTORY)
+
+        set (OUTPUT_FILE ${PROJECT_BINARY_DIR}/${INPUT_BASENAME}cl.hpp)
+
+        message (" Creating XXD Rule for ${INPUT_FILE} -> ${OUTPUT_FILE}")
+        add_custom_command (
+            WORKING_DIRECTORY ${INPUT_DIR}
+            OUTPUT ${OUTPUT_FILE}
+            COMMAND ${XXD_BIN} -i ${INPUT_NAME} > ${OUTPUT_FILE}
+            COMMENT "Building OpenCL Commands in ${INPUT_FILE}"
+            )
+        list (APPEND COMPILED_RESOURCES ${OUTPUT_FILE})
+    endforeach ()
+
+    # Add the OpenCL objects to the library
+    target_sources (qrack PRIVATE
+        ${COMPILED_RESOURCES}
+        src/common/oclengine.cpp
+        src/qengine/state/opencl.cpp
+        )
+
+else (ENABLE_OPENCL)
+    target_compile_definitions (qrack PUBLIC ENABLE_OPENCL=0)
+endif (ENABLE_OPENCL)


### PR DESCRIPTION
* Support ‘make format’ to run clang-format-5.0 against the source files.
* Support ‘coverage’ generation from the unittest results, instructions in README.md.