### PR TITLE
QEngineOCL support for Raspberry Pi 3 (#143)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required (VERSION 3.9)
-project (Qrack VERSION 1.0 DESCRIPTION "High Performance Quantum Bit Simulation")
+project (Qrack VERSION 3.1 DESCRIPTION "High Performance Quantum Bit Simulation")
 
 # Installation commands
 include (GNUInstallDirs)
@@ -78,6 +78,12 @@ include ("cmake/Examples.cmake")
 include ("cmake/OpenCL.cmake" )
 include ("cmake/Complex8.cmake")
 include ("cmake/Complex_x2.cmake")
+include ("cmake/Pure32.cmake")
+
+message ("VC4CL (for Raspberry Pi) support is: ${ENABLE_VC4CL}")
+message ("Pure 32-bit compilation is: ${ENABLE_PURE32}")
+message ("Single accuracy is: ${ENABLE_COMPLEX8}")
+message ("Complex_x2/AVX Support is: ${ENABLE_COMPLEX_X2}")
 
 if (ENABLE_COMPLEX_X2 AND NOT ENABLE_COMPLEX8)
     set(QRACK_COMPILE_OPTS -mavx)

--- a/README.md
+++ b/README.md
@@ -93,6 +93,22 @@ $ cmake -DENABLE_COMPLEX8=ON ..
 ```
 Reduce to float accuracy for complex numbers. Requires half as much RAM (1 additional qubit). Compatible with SSE 1.0 and single precision accelerator devices.
 
+## Pure 32 bit OpenCL kernels
+
+```
+$ cmake -DENABLE_PURE32=ON ..
+```
+This option is needed for certain older or simpler hardware. This removes all use of 64 bit types from the OpenCL kernels, as well as completely removing the use of SIMD intrinsics. Note that this build option theoretically supports only up 32 qubits, whereas `-DENABLE_PURE32=OFF` could support up to 64 qubits, (if the memory requirements were realistically attainable for either 32-bit or 64-bit hardware).
+
+## Raspberry Pi 3 support with VC4CL
+
+```
+$ cmake -DENABLE_VC4CL=ON ..
+```
+This option sets `-DENABLE_PURE32=ON` and additionally branches certain code, in order to support execution on the VideoCore GPU of the Raspberry Pi 3 with the VC4CL OpenCL compiler. Currently, only `Qrack::QEngineOCL` (and specifically not `Qrack::QUnit`) has been successfully built and tested on the Raspberry Pi 3.
+
+This option is probably temporary, due to issues currently being diagnosed and resolved in cooperation with VC4CL. (See VC4CL issues [#54](https://github.com/doe300/VC4CL/issues/54) and [#55](https://github.com/doe300/VC4CL/issues/55).) When those are addressed, -DENABLE_PURE32=ON should be necessary and sufficient to support VC4CL with the Raspberry Pi 3.
+
 ## Copyright and License
 
 Copyright (c) Daniel Strano and the Qrack contributors 2017-2019. All rights reserved.

--- a/cmake/Complex8.cmake
+++ b/cmake/Complex8.cmake
@@ -1,2 +1,1 @@
 option (ENABLE_COMPLEX8 "Use 32 bit float accuracy instead of 64 bit float accuracy" ON)
-message ("Single accuracy is: ${ENABLE_COMPLEX8}")

--- a/cmake/Complex_x2.cmake
+++ b/cmake/Complex_x2.cmake
@@ -1,2 +1,1 @@
 option (ENABLE_COMPLEX_X2 "Use Complex type vector optimizations (including AVX)" ON)
-message ("Complex_x2/AVX Support is: ${ENABLE_COMPLEX_X2}")

--- a/cmake/Pure32.cmake
+++ b/cmake/Pure32.cmake
@@ -1,0 +1,13 @@
+option (ENABLE_PURE32 "Use only 32-bit types or smaller" OFF)
+option (ENABLE_VC4CL "Build a library version that's safe for the VC4CL compiler (for the Raspberry Pi 3)" OFF)
+
+if (ENABLE_VC4CL)
+    set(ENABLE_PURE32 ON)
+    target_compile_definitions(qrack PUBLIC ENABLE_VC4CL=1)
+endif(ENABLE_VC4CL)
+
+if (ENABLE_PURE32)
+    set(ENABLE_COMPLEX_X2 OFF)
+    set(ENABLE_COMPLEX8 ON)
+    target_compile_definitions (qrack PUBLIC ENABLE_PURE32=1)
+endif (ENABLE_PURE32)

--- a/include/common/qrack_types.hpp
+++ b/include/common/qrack_types.hpp
@@ -16,7 +16,11 @@
 #include <random>
 
 #define bitLenInt uint8_t
+#if ENABLE_PURE32
+#define bitCapInt uint32_t
+#else
 #define bitCapInt uint64_t
+#endif
 #define bitsInByte 8
 #define qrack_rand_gen std::mt19937_64
 #define qrack_rand_gen_ptr std::shared_ptr<qrack_rand_gen>

--- a/src/common/oclengine.cpp
+++ b/src/common/oclengine.cpp
@@ -15,7 +15,9 @@
 
 #include "oclengine.hpp"
 
-#if ENABLE_COMPLEX8
+#if ENABLE_PURE32
+#include "qheader32cl.hpp"
+#elif ENABLE_COMPLEX8
 #include "qheader_floatcl.hpp"
 #else
 #include "qheader_doublecl.hpp"
@@ -102,7 +104,9 @@ void OCLEngine::InitOCL()
     // create the programs that we want to execute on the devices
     cl::Program::Sources sources;
 
-#if ENABLE_COMPLEX8
+#if ENABLE_PURE32
+    sources.push_back({ (const char*)qheader32_cl, (long unsigned int)qheader32_cl_len });
+#elif ENABLE_COMPLEX8
     sources.push_back({ (const char*)qheader_float_cl, (long unsigned int)qheader_float_cl_len });
 #else
     sources.push_back({ (const char*)qheader_double_cl, (long unsigned int)qheader_double_cl_len });

--- a/src/common/qheader32.cl
+++ b/src/common/qheader32.cl
@@ -18,7 +18,7 @@
 #define SineShift M_PI_2_F
 #define PI_R1 M_PI_F
 #define min_norm 1e-16f
-#define bitCapInt ulong
-#define bitCapInt2 ulong2
-#define bitCapInt4 ulong4
+#define bitCapInt uint
+#define bitCapInt2 uint2
+#define bitCapInt4 uint4
 #define bitLenInt unsigned char

--- a/src/common/qheader_double.cl
+++ b/src/common/qheader_double.cl
@@ -19,4 +19,8 @@
 #define SineShift M_PI_2
 #define PI_R1 M_PI
 #define min_norm 1e-27
+#define bitCapInt ulong
+#define bitCapInt2 ulong2
+#define bitCapInt4 ulong4
+#define bitLenInt unsigned char
 

--- a/src/qengine/qengine.cpp
+++ b/src/qengine/qengine.cpp
@@ -403,7 +403,7 @@ void QEngine::ProbRegAll(const bitLenInt& start, const bitLenInt& length, real1*
 
 void QEngine::ProbMaskAll(const bitCapInt& mask, real1* probsArray)
 {
-    bitCapInt v = mask; // count the number of bits set in v
+    long v = mask; // count the number of bits set in v
     bitCapInt oldV;
     bitLenInt length;
     std::vector<bitCapInt> powersVec;
@@ -412,7 +412,7 @@ void QEngine::ProbMaskAll(const bitCapInt& mask, real1* probsArray)
         v &= v - 1; // clear the least significant bit set
     }
 
-    v = ~mask; // count the number of bits set in v
+    v = (~mask) & (maxQPower - 1); // count the number of bits set in v
     bitCapInt power;
     bitLenInt len; // c accumulates the total bits set in v
     std::vector<bitCapInt> skipPowersVec;
@@ -420,11 +420,7 @@ void QEngine::ProbMaskAll(const bitCapInt& mask, real1* probsArray)
         oldV = v;
         v &= v - 1; // clear the least significant bit set
         power = (v ^ oldV) & oldV;
-        if (power < mask) {
-            skipPowersVec.push_back(power);
-        } else {
-            v = 0;
-        }
+        skipPowersVec.push_back(power);
     }
 
     bitCapInt lengthPower = 1 << length;

--- a/src/qinterface/gates.cpp
+++ b/src/qinterface/gates.cpp
@@ -195,7 +195,8 @@ void QInterface::CZ(bitLenInt control, bitLenInt target)
     ApplyControlledSingleBit(controls, 1, target, pauliZ);
 }
 
-void QInterface::UniformlyControlledSingleBit(const bitLenInt* controls, const bitLenInt& controlLen, bitLenInt qubitIndex, const complex* mtrxs)
+void QInterface::UniformlyControlledSingleBit(
+    const bitLenInt* controls, const bitLenInt& controlLen, bitLenInt qubitIndex, const complex* mtrxs)
 {
     for (bitLenInt index = 0; index < (1 << controlLen); index++) {
         for (bitLenInt bit_pos = 0; bit_pos < controlLen; bit_pos++) {


### PR DESCRIPTION
* ENABLE_PURE32 cmake option

* Debugging qheader32

* Raspberry Pi 3 build

* BCD bug

* Debugging ProbMask

* Optimizing and debugging QEngineOCL:Clone()

* Shunting VC4CL sin() bug

* make format

* Updating README.md

* Removing commented piece of code

* Per review

* Fixing ProbMaskAll

* Removing phrase from README, per review

* Changing VC4CL macro name

* Comment updates for VC4CL support

* Fixing VC4CL#55 comments