### PR TITLE
Simple QNeuron example (#155)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,6 +140,7 @@ install (FILES
     include/qunitmulti.hpp
     include/qengine_opencl.hpp
     include/qinterface.hpp
+    include/qneuron.hpp
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/qrack
     )
 

--- a/cmake/Examples.cmake
+++ b/cmake/Examples.cmake
@@ -22,6 +22,24 @@ set_target_properties(ordered_list_search PROPERTIES RUNTIME_OUTPUT_DIRECTORY "$
 
 target_link_libraries (ordered_list_search ${QRACK_LIBS})
 
+add_executable (quantum_perceptron
+    examples/quantum_perceptron.cpp
+    )
+
+set_target_properties(quantum_perceptron PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/examples")
+
+target_link_libraries (quantum_perceptron ${QRACK_LIBS})
+
+add_executable (quantum_associative_memory
+    examples/quantum_associative_memory.cpp
+    )
+
+set_target_properties(quantum_associative_memory PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/examples")
+
+target_link_libraries (quantum_associative_memory ${QRACK_LIBS})
+
 target_compile_options (grovers PUBLIC ${TEST_COMPILE_OPTS} -DCATCH_CONFIG_FAST_COMPILE)
 target_compile_options (grovers_lookup PUBLIC ${TEST_COMPILE_OPTS} -DCATCH_CONFIG_FAST_COMPILE)
 target_compile_options (ordered_list_search PUBLIC ${TEST_COMPILE_OPTS} -DCATCH_CONFIG_FAST_COMPILE)
+target_compile_options (quantum_perceptron PUBLIC ${TEST_COMPILE_OPTS} -DCATCH_CONFIG_FAST_COMPILE)
+target_compile_options (quantum_associative_memory PUBLIC ${TEST_COMPILE_OPTS} -DCATCH_CONFIG_FAST_COMPILE)

--- a/cmake/OpenCL.cmake
+++ b/cmake/OpenCL.cmake
@@ -41,6 +41,8 @@ if (ENABLE_OPENCL)
     target_link_libraries (grovers ${OpenCL_LIBRARIES})
     target_link_libraries (grovers_lookup ${OpenCL_LIBRARIES})
     target_link_libraries (ordered_list_search ${OpenCL_LIBRARIES})
+    target_link_libraries (quantum_perceptron ${OpenCL_LIBRARIES})
+    target_link_libraries (quantum_associative_memory ${OpenCL_LIBRARIES})
 
 
     # Build the OpenCL command files

--- a/examples/quantum_associative_memory.cpp
+++ b/examples/quantum_associative_memory.cpp
@@ -1,0 +1,69 @@
+//////////////////////////////////////////////////////////////////////////////////////
+//
+// (C) Daniel Strano and the Qrack contributors 2017-2019. All rights reserved.
+//
+// This example demonstrates an example of a "quantum associative memory" network with the Qrack::QNeuron
+// class. QNeuron is a type of "neuron" that can learn and predict in superposition, for general machine learning
+// purposes.
+//
+// Licensed under the GNU Lesser General Public License V3.
+// See LICENSE.md in the project root or https://www.gnu.org/licenses/lgpl-3.0.en.html
+// for details.
+
+#include <iostream> // For cout
+
+// "qfactory.hpp" pulls in all headers needed to create any type of "Qrack::QInterface."
+#include "qfactory.hpp"
+// "qneuron.hpp" defines the QNeuron class.
+#include "qneuron.hpp"
+
+using namespace Qrack;
+
+int main()
+{
+    const bitLenInt InputCount = 4;
+    const bitLenInt OutputCount = 4;
+    const bitCapInt InputPower = 1U << InputCount;
+    // const bitCapInt OutputPower = 1U << OutputCount;
+    const real1 eta = 1.0;
+
+    // QINTERFACE_OPTIMAL uses the (single-processor) OpenCL engine type, if available. Otherwise, it falls back to
+    // QEngineCPU.
+    QInterfacePtr qReg =
+        CreateQuantumInterface(QINTERFACE_QUNIT, QINTERFACE_QFUSION, QINTERFACE_OPTIMAL, InputCount + OutputCount, 0);
+
+    bitLenInt inputIndices[InputCount];
+    for (bitLenInt i = 0; i < InputCount; i++) {
+        inputIndices[i] = i;
+    }
+
+    std::vector<QNeuronPtr> outputLayer;
+    for (bitLenInt i = 0; i < OutputCount; i++) {
+        outputLayer.push_back(std::make_shared<QNeuron>(qReg, inputIndices, InputCount, InputCount + i));
+    }
+
+    // Train the network to associate powers of 2 with their log2()
+    bitCapInt perm;
+    bitCapInt comp;
+    bool bit;
+    std::cout << "Learning (Two's complement)..." << std::endl;
+    for (perm = 0; perm < InputPower; perm++) {
+        std::cout << "Epoch " << (perm + 1U) << " out of " << InputPower << std::endl;
+        comp = (~perm) + 1U;
+        for (bitLenInt i = 0; i < OutputCount; i++) {
+            qReg->SetPermutation(perm);
+            bit = comp & (1U << i);
+            outputLayer[i]->Learn(bit, eta);
+        }
+    }
+
+    std::cout << "Should associate each input with its two's complement as output..." << std::endl;
+    for (perm = 0; perm < InputPower; perm++) {
+        qReg->SetPermutation(perm);
+        for (bitLenInt i = 0; i < OutputCount; i++) {
+            outputLayer[i]->Predict();
+        }
+        comp = qReg->MReg(InputCount, OutputCount);
+        std::cout << "Input: " << (int)perm << ", Output: " << (int)comp << std::endl;
+    }
+}

--- a/examples/quantum_perceptron.cpp
+++ b/examples/quantum_perceptron.cpp
@@ -1,0 +1,74 @@
+//////////////////////////////////////////////////////////////////////////////////////
+//
+// (C) Daniel Strano and the Qrack contributors 2017-2019. All rights reserved.
+//
+// This example demonstrates a (trivial) example of "quantum neuron" or a "quantum perceptron" with the Qrack::QNeuron
+// class. This is a type of "neuron" that can learn and predict in superposition, for general machine learning purposes.
+//
+// Licensed under the GNU Lesser General Public License V3.
+// See LICENSE.md in the project root or https://www.gnu.org/licenses/lgpl-3.0.en.html
+// for details.
+
+#include <iostream> // For cout
+
+// "qfactory.hpp" pulls in all headers needed to create any type of "Qrack::QInterface."
+#include "qfactory.hpp"
+// "qneuron.hpp" defines the QNeuron class.
+#include "qneuron.hpp"
+
+using namespace Qrack;
+
+int main()
+{
+    const bitLenInt ControlCount = 4;
+    const bitCapInt ControlPower = 1U << ControlCount;
+    const bitLenInt ControlLog = 2;
+    const real1 eta = 1.0;
+
+    // QINTERFACE_OPTIMAL uses the (single-processor) OpenCL engine type, if available. Otherwise, it falls back to
+    // QEngineCPU.
+    QInterfacePtr qReg =
+        CreateQuantumInterface(QINTERFACE_QUNIT, QINTERFACE_QFUSION, QINTERFACE_OPTIMAL, ControlCount + 1, 0);
+
+    bitLenInt inputIndices[ControlCount];
+    for (bitLenInt i = 0; i < ControlCount; i++) {
+        inputIndices[i] = i;
+    }
+
+    QNeuronPtr qPerceptron = std::make_shared<QNeuron>(qReg, inputIndices, ControlCount, ControlCount);
+
+    // Train the network to recognize powers of 2
+    bool isPowerOf2;
+    bitCapInt perm;
+    std::cout << "Learning (to recognize powers of 2)..." << std::endl;
+    for (perm = 0; perm < ControlPower; perm++) {
+        std::cout << "Epoch " << (perm + 1U) << " out of " << ControlPower << std::endl;
+        qReg->SetPermutation(perm);
+        isPowerOf2 = ((perm != 0) && ((perm & (perm - 1U)) == 0));
+        qPerceptron->Learn(isPowerOf2, eta);
+    }
+
+    std::cout << "Should be close to 1 for powers of two, and close to 0 for all else..." << std::endl;
+    for (perm = 0; perm < ControlPower; perm++) {
+        qReg->SetPermutation(perm);
+        std::cout << "Permutation: " << (int)perm << ", Probability: " << qPerceptron->Predict() << std::endl;
+    }
+
+    // Now, we prepare a superposition of all available powers of 2, to predict.
+    bitLenInt* powersOf2 = new bitLenInt[ControlCount];
+    for (bitLenInt i = 0; i < ControlCount; i++) {
+        powersOf2[i] = 1U << i;
+    }
+
+    QInterfacePtr qReg2 =
+        CreateQuantumInterface(QINTERFACE_QUNIT, QINTERFACE_QFUSION, QINTERFACE_OPTIMAL, ControlLog, 0);
+
+    qReg->Compose(qReg2);
+    qReg->SetPermutation(1U << (ControlCount + 1));
+    qReg->H(ControlCount + 1, ControlLog);
+    qReg->IndexedLDA(ControlCount + 1, ControlLog, 0, ControlCount, powersOf2);
+    qReg->H(ControlCount + 1, ControlLog);
+    qReg->Dispose(ControlCount + 1, ControlLog);
+
+    std::cout << "(Superposition of all powers of 2) Probability: " << qPerceptron->Predict() << std::endl;
+}

--- a/include/qneuron.hpp
+++ b/include/qneuron.hpp
@@ -1,0 +1,121 @@
+//////////////////////////////////////////////////////////////////////////////////////
+//
+// (C) Daniel Strano and the Qrack contributors 2017-2019. All rights reserved.
+//
+// This is a multithreaded, universal quantum register simulation, allowing
+// (nonphysical) register cloning and direct measurement of probability and
+// phase, to leverage what advantages classical emulation of qubits can have.
+//
+// Licensed under the GNU Lesser General Public License V3.
+// See LICENSE.md in the project root or https://www.gnu.org/licenses/lgpl-3.0.en.html
+// for details.
+
+#pragma once
+
+#include "qinterface.hpp"
+
+namespace Qrack {
+
+class QNeuron;
+typedef std::shared_ptr<QNeuron> QNeuronPtr;
+
+class QNeuron {
+private:
+    QInterfacePtr qReg;
+    bitLenInt* inputIndices;
+    bitLenInt inputCount;
+    bitCapInt inputPower;
+    bitLenInt outputIndex;
+    real1* angles;
+
+    const real1 tolerance = 1e-6;
+
+public:
+    /** "Quantum neuron" or "quantum perceptron" class that can learn and predict in superposition
+     *
+     * This is a simple "quantum neuron" or "quantum perceptron" class, for use of the Qrack library for machine
+     * learning. See https://arxiv.org/abs/1711.11240 for the basis of this class' theoretical concept. (That paper does
+     * not use the term "uniformly controlled rotation gate," but "conditioning on all controls" is computationally the
+     * same.) */
+    QNeuron(QInterfacePtr reg, bitLenInt* inputIndcs, bitLenInt inputCnt, bitLenInt outputIndx)
+        : inputCount(inputCnt)
+        , inputPower(1U << inputCnt)
+        , outputIndex(outputIndx)
+    {
+        qReg = reg;
+
+        inputIndices = new bitLenInt[inputCount];
+        std::copy(inputIndcs, inputIndcs + inputCount, inputIndices);
+
+        angles = new real1[inputPower];
+        std::fill(angles, angles + inputPower, ZERO_R1);
+    }
+
+    /** Create a new QNeuron which is an exact duplicate of another, including its learned state. */
+    QNeuron(const QNeuron& toCopy)
+        : QNeuron(toCopy.qReg, toCopy.inputIndices, toCopy.inputCount, toCopy.outputIndex)
+    {
+        std::copy(toCopy.angles, toCopy.angles + inputPower, angles);
+    }
+
+    ~QNeuron()
+    {
+        delete[] inputIndices;
+        delete[] angles;
+    }
+
+    /** Feed-forward from the inputs, loaded in "qReg", to a binary categorical distinction. "expected" flips the binary
+     * categories, if false. */
+    real1 Predict(bool expected = true)
+    {
+        qReg->SetBit(outputIndex, false);
+        qReg->UniformlyControlledRY(inputIndices, inputCount, outputIndex, angles);
+        real1 prob = qReg->Prob(outputIndex);
+        if (!expected) {
+            prob = ONE_R1 - prob;
+        }
+        return prob;
+    }
+
+    /** Perform one learning iteration
+     *
+     * Inputs must be already loaded into "qReg" before calling this method. "expected" is the true binary output
+     * category, for training. "eta" is a volatility or "learning rate" parameter with a maximum value of 1.
+     */
+    void Learn(bool expected, real1 eta)
+    {
+        real1 startProb, endProb;
+
+        startProb = Predict(expected);
+        if (startProb > (ONE_R1 - tolerance)) {
+            return;
+        }
+
+        for (bitCapInt perm = 0; perm < inputPower; perm++) {
+            angles[perm] += eta * M_PI;
+
+            endProb = Predict(expected);
+            if (endProb > (ONE_R1 - tolerance)) {
+                return;
+            }
+
+            if (endProb > startProb) {
+                startProb = endProb;
+            } else {
+                angles[perm] -= 2 * eta * M_PI;
+
+                endProb = Predict(expected);
+                if (endProb > (ONE_R1 - tolerance)) {
+                    return;
+                }
+
+                if (endProb > startProb) {
+                    startProb = endProb;
+                } else {
+                    angles[perm] += eta * M_PI;
+                }
+            }
+        }
+    }
+};
+} // namespace Qrack

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -331,11 +331,11 @@ void QEngineOCL::SetDevice(const int& dID, const bool& forceReInit)
     size_t nrmVecAlignSize =
         ((sizeof(real1) * nrmGroupCount) < ALIGN_SIZE) ? ALIGN_SIZE : (sizeof(real1) * nrmGroupCount);
 
-	if (didInit && (nrmGroupCount != oldNrmGroupCount)) {
+    if (didInit && (nrmGroupCount != oldNrmGroupCount)) {
         nrmBuffer = NULL;
         FreeAligned(nrmArray);
         nrmArray = NULL;
-	}
+    }
 
     if (!didInit || (nrmGroupCount != oldNrmGroupCount)) {
 #if defined(__APPLE__)
@@ -730,7 +730,8 @@ void QEngineOCL::Compose(OCLAPI apiCall, bitCapInt* bciArgs, QEngineOCLPtr toCop
         toCopy->LockSync(CL_MAP_READ);
         std::copy(toCopy->stateVec, toCopy->stateVec + toCopy->maxQPower, otherStateVec);
         toCopy->UnlockSync();
-        otherStateBuffer = std::make_shared<cl::Buffer>(context, CL_MEM_USE_HOST_PTR | CL_MEM_READ_WRITE, sizeof(complex) * toCopy->maxQPower, otherStateVec);
+        otherStateBuffer = std::make_shared<cl::Buffer>(
+            context, CL_MEM_USE_HOST_PTR | CL_MEM_READ_WRITE, sizeof(complex) * toCopy->maxQPower, otherStateVec);
     }
 
     runningNorm = ONE_R1;
@@ -904,7 +905,8 @@ void QEngineOCL::DecomposeDispose(bitLenInt start, bitLenInt length, QEngineOCLP
             otherStateBuffer = destination->stateBuffer;
         } else {
             otherStateVec = AllocStateVec(destination->maxQPower, true);
-            otherStateBuffer = std::make_shared<cl::Buffer>(context, CL_MEM_USE_HOST_PTR | CL_MEM_READ_WRITE, sizeof(complex) * destination->maxQPower, otherStateVec);
+            otherStateBuffer = std::make_shared<cl::Buffer>(context, CL_MEM_USE_HOST_PTR | CL_MEM_READ_WRITE,
+                sizeof(complex) * destination->maxQPower, otherStateVec);
 
             DISPATCH_FILL(
                 waitVec2, *otherStateBuffer, sizeof(complex) * destination->maxQPower, complex(ZERO_R1, ZERO_R1));
@@ -1900,7 +1902,8 @@ bool QEngineOCL::ApproxCompare(QEngineOCLPtr toCompare)
         toCompare->LockSync(CL_MAP_READ);
         std::copy(toCompare->stateVec, toCompare->stateVec + toCompare->maxQPower, otherStateVec);
         toCompare->UnlockSync();
-        otherStateBuffer = std::make_shared<cl::Buffer>(context, CL_MEM_USE_HOST_PTR | CL_MEM_READ_WRITE, sizeof(complex) * toCompare->maxQPower, otherStateVec);
+        otherStateBuffer = std::make_shared<cl::Buffer>(
+            context, CL_MEM_USE_HOST_PTR | CL_MEM_READ_WRITE, sizeof(complex) * toCompare->maxQPower, otherStateVec);
     }
 
     QueueCall(OCL_API_APPROXCOMPARE, nrmGroupCount, nrmGroupSize,
@@ -1923,12 +1926,11 @@ QInterfacePtr QEngineOCL::Clone()
     QEngineOCLPtr copyPtr = std::make_shared<QEngineOCL>(
         qubitCount, 0, rand_generator, complex(ONE_R1, ZERO_R1), doNormalize, randGlobalPhase, useHostRam, deviceID);
 
-	copyPtr->clFinish();
+    copyPtr->clFinish();
 
-	copyPtr->runningNorm = runningNorm;
-	//WAIT_COPY(*stateBuffer, *(copyPtr->stateBuffer), sizeof(complex) * maxQPower);
+    copyPtr->runningNorm = runningNorm;
 
-	LockSync(CL_MAP_READ);
+    LockSync(CL_MAP_READ);
     copyPtr->LockSync(CL_MAP_WRITE);
     std::copy(stateVec, stateVec + maxQPower, copyPtr->stateVec);
     UnlockSync();
@@ -2015,7 +2017,8 @@ complex* QEngineOCL::AllocStateVec(bitCapInt elemCount, bool doForceAlloc)
         &toRet, ALIGN_SIZE, ((sizeof(complex) * elemCount) < ALIGN_SIZE) ? ALIGN_SIZE : sizeof(complex) * elemCount);
     return (complex*)toRet;
 #elif defined(_WIN32) && !defined(__CYGWIN__)
-    return (complex*)_aligned_malloc(((sizeof(complex) * elemCount) < ALIGN_SIZE) ? ALIGN_SIZE : sizeof(complex) * elemCount, ALIGN_SIZE);
+    return (complex*)_aligned_malloc(
+        ((sizeof(complex) * elemCount) < ALIGN_SIZE) ? ALIGN_SIZE : sizeof(complex) * elemCount, ALIGN_SIZE);
 #else
     return (complex*)aligned_alloc(
         ALIGN_SIZE, ((sizeof(complex) * elemCount) < ALIGN_SIZE) ? ALIGN_SIZE : sizeof(complex) * elemCount);

--- a/src/qengine/state.cpp
+++ b/src/qengine/state.cpp
@@ -764,7 +764,8 @@ complex* QEngineCPU::AllocStateVec(bitCapInt elemCount, bool ovrride)
         &toRet, ALIGN_SIZE, ((sizeof(complex) * elemCount) < ALIGN_SIZE) ? ALIGN_SIZE : sizeof(complex) * elemCount);
     return (complex*)toRet;
 #elif defined(_WIN32) && !defined(__CYGWIN__)
-    return (complex*)_aligned_malloc(((sizeof(complex) * elemCount) < ALIGN_SIZE) ? ALIGN_SIZE : sizeof(complex) * elemCount, ALIGN_SIZE);
+    return (complex*)_aligned_malloc(
+        ((sizeof(complex) * elemCount) < ALIGN_SIZE) ? ALIGN_SIZE : sizeof(complex) * elemCount, ALIGN_SIZE);
 #else
     return (complex*)aligned_alloc(
         ALIGN_SIZE, ((sizeof(complex) * elemCount) < ALIGN_SIZE) ? ALIGN_SIZE : sizeof(complex) * elemCount);

--- a/src/qinterface/protected.cpp
+++ b/src/qinterface/protected.cpp
@@ -25,7 +25,9 @@ unsigned char* qrack_alloc(size_t ucharCount)
         ((sizeof(unsigned char) * ucharCount) < ALIGN_SIZE) ? ALIGN_SIZE : (sizeof(unsigned char) * ucharCount));
     return (unsigned char*)toRet;
 #elif defined(_WIN32) && !defined(__CYGWIN__)
-    return (unsigned char*)_aligned_malloc(((sizeof(unsigned char) * ucharCount) < ALIGN_SIZE) ? ALIGN_SIZE : (sizeof(unsigned char) * ucharCount), ALIGN_SIZE);
+    return (unsigned char*)_aligned_malloc(
+        ((sizeof(unsigned char) * ucharCount) < ALIGN_SIZE) ? ALIGN_SIZE : (sizeof(unsigned char) * ucharCount),
+        ALIGN_SIZE);
 #else
     return (unsigned char*)aligned_alloc(ALIGN_SIZE,
         ((sizeof(unsigned char) * ucharCount) < ALIGN_SIZE) ? ALIGN_SIZE : (sizeof(unsigned char) * ucharCount));


### PR DESCRIPTION
* Simple QNeuron example

* Correcting 'eta' scaling; showing example of superposed classification

* Fixing perceptron superposition bug

* Quantum associative memory example

* QFactory call bug for CPU

* Per review

* Simplifying examples