### PR TITLE
QNeuron initial conditions (#164)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,4 @@ script:
   - mkdir _build && cd _build && cmake -DUSE_OPENCL=OFF -DENABLE_COMPLEX8=OFF .. && make -j 8 all
   - cd .. && rm -r _build
   - mkdir _build && cd _build && cmake -DUSE_OPENCL=OFF -DENABLE_COMPLEX8=ON .. && make -j 8 all
+  - ./unittest --proc-cpu

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -2852,5 +2852,4 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_qneuron")
         test = ((~perm) + 1U) & (OutputPower - 1);
         REQUIRE(comp == test);
     }
-
 }


### PR DESCRIPTION
* QNeuron init. conditions and documentation

* Init. changed based on use case

* Bias-only QNeurons

* Angle/'eta' convention

* 0.5 probability is M_PI_2 rotation

* Learn() does not reset output

* Default init on Learn for QNeuron

* Fixing QNeuron LearnPermutation

* Fixing LearnPermutation M()

* Removing outdated TODO

* Update Travis to run unit tests

* QNeuron method param. documentation